### PR TITLE
Both project and patch targets hit.

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        # basic
+        target: 80% # coverage we are trying to achieve
+        threshold: 2% # coverage difference allowed to succeed
+        base: auto

--- a/src/main/java/com/evisions/Subtractor.java
+++ b/src/main/java/com/evisions/Subtractor.java
@@ -1,0 +1,8 @@
+package com.evisions;
+
+/**
+ * Created by gabe.clark on 7/7/17.
+ */
+public class Subtractor {
+    static int subtract(int a, int b) { return a - b; }
+}


### PR DESCRIPTION
This should fail because coverage dropped by a percentage greater than the threshold. Coverage should also fail because coverage is less than target percentage. 